### PR TITLE
[add][PILLUP-322] Zustand Persist 작업 및 localStorage 연동 완료

### DIFF
--- a/components/common/MyPillList.tsx
+++ b/components/common/MyPillList.tsx
@@ -1,35 +1,26 @@
 import PillView from './PillView'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
-import { SupplementDetailsType } from '../../utils/types'
 import requests from '../../utils/requests'
+import useGetLocalPillList from '../../hooks/useGetLocalPillList'
 
 function MyPillList() {
-  const [userTakingPillList, setUserTakingPillList] = useState<SupplementDetailsType[]>([])
-
-  useEffect(() => {
-    // localStorage에서 'userTakingPillList'라는 key이름으로 데이터를 꺼내봄.
-    const jsonLocalTakingPillList = localStorage.getItem('userTakingPillList')
-    // 만약 있다면 (null이 아니라면) if문 안의 내용 실행
-    if (jsonLocalTakingPillList !== null) {
-      // localStorage에 넣을 때 Json으로 바꿔주므로 다시 되돌리기 위해 파싱
-      const localTakingPillList: SupplementDetailsType[] = JSON.parse(jsonLocalTakingPillList)
-      setUserTakingPillList(localTakingPillList)
-    }
-  }, [])
+  // 랜더링 문제로 Zustand 훅 안쓰고 localStorage에서 직접 가져오는 커스텀 훅 사용
+  const userTakingPillList = useGetLocalPillList()
 
   return (
     <Link href='/'>
       <a>
-        <div className='w-full px-2'>
-          <h1 className='text-xl font-bold px-3'>내 영양제 {'>'}</h1>
+        <div className='w-full px-5'>
+          <h1 className='text-xl font-bold'>내 영양제 {'>'}</h1>
           <div className='flex space-x-1.5 mt-5 overflow-x-scroll scrollbar-hide'>
-            {userTakingPillList?.length !== 0 &&
+            {userTakingPillList?.length !== 0 ?
               userTakingPillList.map((pill) => {
                 return(
                   <PillView key={pill.id} imageUrl={requests.fetchSupplementThumbnail(pill.id.toString())} name={pill.name} />
                 )
-              })
+              }) : (
+                <p className='text-sm'>등록된 영양제가 없어요! 영양제를 등록해보세요.</p>
+              )
             }
           </div>
         </div>

--- a/components/common/MyPillList.tsx
+++ b/components/common/MyPillList.tsx
@@ -1,11 +1,11 @@
 import PillView from './PillView'
 import Link from 'next/link'
 import requests from '../../utils/requests'
-import useGetLocalPillList from '../../hooks/useGetLocalPillList'
+import useUserPillList from '../../hooks/useUserPillList'
 
 function MyPillList() {
-  // 랜더링 문제로 Zustand 훅 안쓰고 localStorage에서 직접 가져오는 커스텀 훅 사용
-  const userTakingPillList = useGetLocalPillList()
+  // // 랜더링 문제로 Zustand 훅 안쓰고 커스텀 훅 사용 (노션 참고)
+  const userTakingPillList = useUserPillList()
 
   return (
     <Link href='/'>
@@ -13,7 +13,7 @@ function MyPillList() {
         <div className='w-full px-5'>
           <h1 className='text-xl font-bold'>내 영양제 {'>'}</h1>
           <div className='flex space-x-1.5 mt-5 overflow-x-scroll scrollbar-hide'>
-            {userTakingPillList?.length !== 0 ?
+            {userTakingPillList.length !== 0 ?
               userTakingPillList.map((pill) => {
                 return(
                   <PillView key={pill.id} imageUrl={requests.fetchSupplementThumbnail(pill.id.toString())} name={pill.name} />

--- a/hooks/useGetLocalPillList.ts
+++ b/hooks/useGetLocalPillList.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 import { SupplementDetailsType } from '../utils/types'
 
+
+/**
+ * ************* 폐기 예정인 훅 *************
+ * **/
+
+
 const useGetLocalPillList = (): SupplementDetailsType[] => {
   const [userTakingPillList, setUserTakingPillList] = useState<SupplementDetailsType[]>([])
 

--- a/hooks/useGetLocalPillList.ts
+++ b/hooks/useGetLocalPillList.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import { SupplementDetailsType } from '../utils/types'
+
+const useGetLocalPillList = (): SupplementDetailsType[] => {
+  const [userTakingPillList, setUserTakingPillList] = useState<SupplementDetailsType[]>([])
+
+  useEffect(() => {
+    // localStorage에서 'userTakingPillList'라는 key이름으로 데이터를 꺼내봄.
+    const jsonLocalTakingPillList = localStorage.getItem('userTakingPillList')
+    // 만약 있다면 (null이 아니라면) if문 안의 내용 실행
+    if (jsonLocalTakingPillList !== null) {
+      // localStorage에 넣을 때 Json으로 바꿔줬으므로 다시 되돌리기 위해 파싱
+      const localTakingPillList = JSON.parse(jsonLocalTakingPillList)
+      if (localTakingPillList.state.userTakingPillList.length !== 0) {
+        setUserTakingPillList(localTakingPillList.state.userTakingPillList)
+      }
+    }
+  }, [])
+
+  return userTakingPillList
+}
+
+export default useGetLocalPillList

--- a/hooks/useUserPillList.ts
+++ b/hooks/useUserPillList.ts
@@ -1,0 +1,14 @@
+import { useUserPillListStore } from '../stores/store'
+import { useEffect, useState } from 'react'
+import { SupplementDetailsType } from '../utils/types'
+
+const useUserPillList = (): SupplementDetailsType[] => {
+  const { userTakingPillList } = useUserPillListStore()
+  const [pillList, setPillList] = useState<SupplementDetailsType[]>([])
+
+  useEffect(() => setPillList(userTakingPillList), [])
+
+  return pillList
+}
+
+export default useUserPillList

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "next": "12.2.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "tailwind-scrollbar-hide": "^1.1.7"
+        "tailwind-scrollbar-hide": "^1.1.7",
+        "zustand": "^4.0.0"
       },
       "devDependencies": {
         "@types/node": "^18.0.3",
@@ -4983,6 +4984,37 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/zustand": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0.tgz",
+      "integrity": "sha512-OrsfQTnRXF1LZ9/vR/IqN9ws5EXUhb149xmPjErZnUrkgxS/gAHGy2dPNIVkVvoxrVe1sIydn4JjF0dYHmGeeQ==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     }
   },
   "dependencies": {
@@ -8241,6 +8273,22 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
       "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0.tgz",
+      "integrity": "sha512-OrsfQTnRXF1LZ9/vR/IqN9ws5EXUhb149xmPjErZnUrkgxS/gAHGy2dPNIVkVvoxrVe1sIydn4JjF0dYHmGeeQ==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "dependencies": {
+        "use-sync-external-store": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+          "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+          "requires": {}
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "12.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwind-scrollbar-hide": "^1.1.7"
+    "tailwind-scrollbar-hide": "^1.1.7",
+    "zustand": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.3",

--- a/pages/pill-details/[id].tsx
+++ b/pages/pill-details/[id].tsx
@@ -18,6 +18,7 @@ import EfficiencyTag from '../../components/tag/EfficiencyTag'
 import requests from '../../utils/requests'
 import { SupplementDetailsType } from '../../utils/types'
 import axios from 'axios'
+import { useUserPillListStore } from '../../stores/store'
 
 interface Props {
   details: SupplementDetailsType
@@ -29,29 +30,23 @@ const Details = ({ details }: Props) => {
   const [isTaking, setIsTaking] = useState<boolean>(false)
   const [isOpenEfficiency, setIsOpenEfficiency] = useState<boolean>(false)
   const { id, name, dailyDose, intakeTiming, maker, ingredients } = details
-  const [userTakingPillList, setUserTakingPillList] = useState<SupplementDetailsType[]>([])
+  const { userTakingPillList, setUserTakingPillList } = useUserPillListStore()
 
-  console.log(details)
-  console.log(id, dailyDose, intakeTiming, name)
+  console.log(userTakingPillList)
 
-  // 최초 페이지 진입 시 실행 후 종료
-  // localStorage에 해당 페이지 영양제가 등록되어 있는지 확인하고 있으면 섭취중인 영양제로 표시
+  // 최초 페이지 진입 시 한 번 실행 후 종료
+  // 해당 페이지 영양제가 등록되어 있는지 확인하고 있으면 섭취중인 영양제로 표시
   useEffect(() => {
-    // localStorage에서 'userTakingPillList'라는 key이름으로 데이터를 꺼내봄.
-    const jsonLocalTakingPillList = localStorage.getItem('userTakingPillList')
-    // 만약 있다면 (null이 아니라면) if문 안의 내용 실행
-    if (jsonLocalTakingPillList !== null) {
-      // localStorage에 넣을 때 Json으로 바꿔주므로 다시 되돌리기 위해 파싱
-      const localTakingPillList: SupplementDetailsType[] = JSON.parse(jsonLocalTakingPillList)
+    // 만약 등록한 영양제가 있다면 if문 안의 내용 실행
+    if (userTakingPillList.length !== 0) {
       // 객체 배열인 localTakingPillList에서 현재 페이지의 영양제의 id와 같은 객체 값이 있는지 find함수로 확인
       // 있다면 객체가 반환되고 없으면 undefined가 반환
-      const matchOne: SupplementDetailsType | undefined = localTakingPillList.find(x => x.id === id)
+      const matchOne: SupplementDetailsType | undefined = userTakingPillList.find(x => x.id === id)
       if (matchOne !== undefined) {
         setIsTaking(true)
       } else {  // 사실 굳이 필요없는 else이긴 함. 안정성을 위해 일단 추가
         setIsTaking(false)
       }
-      setUserTakingPillList(localTakingPillList)
     }
   }, [])
 
@@ -59,21 +54,15 @@ const Details = ({ details }: Props) => {
   const takingSubmit = (curIsTaking: boolean) => {
     // 현재 섭취중이 아니라면
     if (!curIsTaking) {
-      console.log(userTakingPillList)
-      console.log(userTakingPillList.concat(details))
-      // 기존 유저 섭취 영양제 리스트 배열에 현재 영양제 페이지의 영양제 객체 값 추가 (이게 필요한지는 조금 더 생각해봐야 할 듯)
+      // 기존 유저 섭취 영양제 리스트 배열에 현재 영양제 페이지의 영양제 객체 값 추가 (localStorage 에도 반영됨)
       setUserTakingPillList(userTakingPillList.concat(details))
-      // localStorage에도 추가해서 저장
-      localStorage.setItem('userTakingPillList', JSON.stringify(userTakingPillList.concat(details)))
       // 다 끝나면 섭취 체크
       setIsTaking(true)
     } else {  // 만약 섭취중이라면
       // userTakingPillList 배열에서 해당 값을 삭제하기
       const removedList: SupplementDetailsType[] = userTakingPillList.filter(x => x.id !== id)
-      // state 값 수정
+      // 기존 유저 섭취 영양제 리스트 배열 업데이트하기 (localStorage 에도 반영됨)
       setUserTakingPillList(removedList)
-      // localStorage 값도 수정
-      localStorage.setItem('userTakingPillList', JSON.stringify(removedList))
       // 다 끝나면 섭취 해제 체크
       setIsTaking(false)
     }

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,0 +1,19 @@
+import create from 'zustand'
+import { persist } from 'zustand/middleware'
+import { SupplementDetailsType } from '../utils/types'
+import { pillListPersist, pillListState } from './storeTypes'
+
+export const useUserPillListStore = create<pillListState>(
+  // @ts-ignore
+  (persist as pillListPersist)(
+    (set) => ({
+      userTakingPillList: [],
+      setUserTakingPillList: (data: SupplementDetailsType[]) => {
+        set((state) => ({...state, userTakingPillList: data}))
+      }
+    }),
+    {
+      name: 'userTakingPillList'
+    }
+  )
+)

--- a/stores/storeTypes.ts
+++ b/stores/storeTypes.ts
@@ -1,0 +1,17 @@
+import { SupplementDetailsType } from '../utils/types'
+import { StateCreator } from 'zustand'
+import { PersistOptions } from 'zustand/middleware'
+
+// export const dummyStorageApi = {
+//   getItem: () => null,
+//   setItem: () => undefined,
+// }
+
+export type pillListState = {
+  userTakingPillList: SupplementDetailsType[]
+  setUserTakingPillList: (data: SupplementDetailsType[]) => void
+}
+export type pillListPersist = (
+  config: StateCreator<pillListState>,
+  options: PersistOptions<pillListState>
+) => StateCreator<pillListState>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,7 +2042,7 @@
   "resolved" "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   "version" "16.13.1"
 
-"react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@^18.2.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16.3", "react@18.2.0":
+"react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@^18.2.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16.3", "react@>=16.8", "react@18.2.0":
   "integrity" "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="
   "resolved" "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   "version" "18.2.0"
@@ -2471,6 +2471,11 @@
   "resolved" "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz"
   "version" "1.1.0"
 
+"use-sync-external-store@1.2.0":
+  "integrity" "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+  "resolved" "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz"
+  "version" "1.2.0"
+
 "util-deprecate@^1.0.2":
   "integrity" "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
   "resolved" "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -2541,3 +2546,10 @@
   "integrity" "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
   "resolved" "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz"
   "version" "2.1.1"
+
+"zustand@^4.0.0":
+  "integrity" "sha512-OrsfQTnRXF1LZ9/vR/IqN9ws5EXUhb149xmPjErZnUrkgxS/gAHGy2dPNIVkVvoxrVe1sIydn4JjF0dYHmGeeQ=="
+  "resolved" "https://registry.npmjs.org/zustand/-/zustand-4.0.0.tgz"
+  "version" "4.0.0"
+  dependencies:
+    "use-sync-external-store" "1.2.0"


### PR DESCRIPTION
### Zustand Persist로 전역 상태관리 및 localStorage와 자동 연동되도록 개발하였습니다.
- 발생한 이슈에 관한 내용은 아래 링크에서 확인할 수 있습니다.
[Zustand 상태 관리](https://www.notion.so/swm13-alchemists/Zustand-ac68b9881f0b4d3bbc917e15174d2206)
- 상태 관리 라이브러리 Zustand를 적용하였습니다.
- 기존 localStorage에서 관리되던 데이터들이 Zustand Persist를 통해 전역으로 관리됩니다.
- Hydration failed 에러가 발생하는 컴포넌트의 경우 커스텀 훅을 만들어 직접 localStorage에서 데이터를 가져오는 방식으로 오류를 해결하였습니다.  
  
(+ tsconfig에 "noImplicitAny": true, "strictNullChecks": true를 설정하였습니다.)